### PR TITLE
Added pagination of footprints

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -90,6 +90,7 @@
     "react-dom": "^16.12.0",
     "requirejs": "^2.3.6",
     "typeface-roboto": "0.0.75",
-    "wicket": "1.3.5"
+    "wicket": "1.3.5",
+    "leaflet-html-legend":"0.3.5"
   }
 }

--- a/app/src/js/ApiJsonCollection.js
+++ b/app/src/js/ApiJsonCollection.js
@@ -16,7 +16,7 @@ function getItemCollection(name, page) {
             var url = result.collections[i].links[j].href;
             // this is temporary until stac.astrogeology is working with pagination
             url = url.replace("https://stac.astrogeology.usgs.gov/api/collections", "https://jat52qc8c0.execute-api.us-west-2.amazonaws.com/dev/collections");
-            url += "?page1";
+            url = url + "?page=" + page;
             urlArray.push(url);
           }
          }

--- a/app/src/js/ApiJsonCollection.js
+++ b/app/src/js/ApiJsonCollection.js
@@ -1,11 +1,10 @@
-
-
+//https://jat52qc8c0.execute-api.us-west-2.amazonaws.com/dev/collections
 function callAPI() {
     return fetch("https://stac.astrogeology.usgs.gov/api/collections")
            .then(response => response.json());
 }
 
-function getItemCollection(name) {
+function getItemCollection(name, page) {
   var urlArray = [];
   return callAPI().then(result => {
     for (let i = 0; i < result.collections.length; i++) {
@@ -14,7 +13,10 @@ function getItemCollection(name) {
         for (let j = 0; j < length; j++) {
           let link = result.collections[i].links[j];
           if (link.rel == 'items') {
-            var url = new URL(result.collections[i].links[j].href);
+            var url = result.collections[i].links[j].href;
+            // this is temporary until stac.astrogeology is working with pagination
+            url = url.replace("https://stac.astrogeology.usgs.gov/api/collections", "https://jat52qc8c0.execute-api.us-west-2.amazonaws.com/dev/collections");
+            url += "?page1";
             urlArray.push(url);
           }
          }
@@ -25,7 +27,7 @@ function getItemCollection(name) {
      }
      let promiseArray = [];
      for (let i = 0; i < urlArray.length; i++) {
-       promiseArray.push(fetch(urlArray[i]))
+       promiseArray.push(fetch(urlArray[i]));
      }
      return Promise.all(promiseArray).then(function (responses) {
         return Promise.all(responses.map(function (response) {

--- a/app/src/js/ApiJsonCollection.js
+++ b/app/src/js/ApiJsonCollection.js
@@ -1,4 +1,4 @@
-//https://jat52qc8c0.execute-api.us-west-2.amazonaws.com/dev/collections
+
 function callAPI() {
     return fetch("https://stac.astrogeology.usgs.gov/api/collections")
            .then(response => response.json());

--- a/app/src/js/AstroMap.js
+++ b/app/src/js/AstroMap.js
@@ -118,7 +118,9 @@ export default L.Map.AstroMap = L.Map.extend({
    * @function AstroMap.prototype.loadFootprintLayer
    * @description Adds the ApiJsonCollection with the requested name.
    *
-   * @param {String} name - Name of the STAC Catalog. example "ctx_dtms"
+   * @param {String} name - Name of the target
+   *
+   * @param {Int} page - current selected page number of the pagination
    */
   loadFootprintLayer: function(name, page) {
     getItemCollection(name, page).then(result => {
@@ -141,7 +143,9 @@ export default L.Map.AstroMap = L.Map.extend({
    * @function AstroMap.prototype.addFootprintLegend
    * @description Adds legend for each footprint layer
    *
-   * @param {Object} footprintCollection - dictonary of footprint layers
+   * @param {String} name - Name of the projection
+   *
+   * @param {Int} page - current selected page number of the pagination
    */
   addFootprintLegend: function(name, page) {
     var self = this;

--- a/app/src/js/AstroMap.js
+++ b/app/src/js/AstroMap.js
@@ -5,6 +5,7 @@ import AstroProj from "./AstroProj";
 import LayerCollection from "./LayerCollection";
 import { getItemCollection, url } from "./ApiJsonCollection";
 import { MY_JSON_MAPS } from "./layers";
+import "leaflet-html-legend";
 
 /**
  * @class AstroMap
@@ -120,18 +121,59 @@ export default L.Map.AstroMap = L.Map.extend({
     var geoLayers = [];
     var footprintCollection = {};
 
-    getItemCollection(name).then(result => {
-      if (result != undefined){
+    getItemCollection(name, 1).then(result => {
+      if (result != undefined) {
         for (let i = 0; i < result.length; i++) {
-          let geoLayer = L.geoJSON().addTo(this);
+          let geoLayer = L.geoJSON();
           footprintCollection[result[i].features[0].collection] = geoLayer;
           for (let j = 0; j < result[i].features.length; j++) {
             geoLayer.addData(result[i].features[j]);
           }
         }
         L.control.layers(null, footprintCollection).addTo(this);
+        this.addFootprintLegend(name, footprintCollection);
       }
-    });   
+    });
+  },
+
+
+  /**
+   * @function AstroMap.prototype.addFootprintLegend
+   * @description Adds legend for each footprint layer
+   *
+   * @param {Object} footprintCollection - dictonary of footprint layers
+   */
+  addFootprintLegend: function(name, footprintCollection) {
+    for (const layer in footprintCollection) {
+      var legend = L.control.htmllegend({
+        legends: [{
+            name: layer,
+            layer: footprintCollection[layer],
+            elements: [{
+                html: `<div class="pagination">
+                        <a id="left">&laquo;</a>
+                        <a id="pageNumber">1</a>
+                        <a id="right">&raquo;</a>
+                      </div>`
+            }]
+         }]
+      });
+      this.addControl(legend);
+    }
+    var left = document.getElementById('left');
+    var right = document.getElementById('right');
+    var page = document.getElementById('pageNumber');
+
+    left.onclick = function(){
+      if (page.innerHTML > 1){
+        page.innerHTML = parseInt(page.innerHTML) - 1;
+      }
+    };
+    right.onclick = function(){
+      if (page.innerHTML >= 1){
+        page.innerHTML = parseInt(page.innerHTML) + 1;
+      }
+    };
   },
 
   /**

--- a/app/src/styles.css
+++ b/app/src/styles.css
@@ -1,6 +1,8 @@
 @import "../node_modules/leaflet/dist/leaflet.css";
 @import "../node_modules/leaflet-fullscreen/dist/leaflet.fullscreen.css";
 @import "https://cdnjs.cloudflare.com/ajax/libs/leaflet.draw/1.0.4/leaflet.draw.css";
+@import "../node_modules/leaflet-html-legend/dist/L.Control.HtmlLegend.css";
+
 
 #map-container {
   width: 800px;
@@ -87,4 +89,15 @@ Controls the CSS for projection buttons when there is no available projection
 
 .sidebar-button:hover {
   background-color: #ccc;
+}
+
+.pagination {
+   display: inline-block;
+}
+
+.pagination a {
+  color: black;
+  float: left;
+  padding: 8px 16px;
+  text-decoration: none;
 }


### PR DESCRIPTION
I was unable to get the pagination working for separate layers when separating by mission. Since this was considered a stretch goal, I simplified to only a single footprint layer.

There are still todo's for the pagination. Including having a check for the max number of pages. Not sure how to handle this with multiple collections with different possible page numbers.

This PR also adds a temporary link for obtaining the footprints. This will stay as is so we can continue to work on the project. Will change back once original API is fixed. 

Closes #3 