### PR TITLE
Add console.log output when clicking footprint.

### DIFF
--- a/app/src/js/AstroMap.js
+++ b/app/src/js/AstroMap.js
@@ -125,7 +125,10 @@ export default L.Map.AstroMap = L.Map.extend({
   loadFootprintLayer: function(name, page) {
     getItemCollection(name, page).then(result => {
       if (result != undefined) {
-        this._geoLayer = L.geoJSON().addTo(this);
+        this._geoLayer = L.geoJSON()
+          .on('click', function(e){
+            console.log(e);
+        }).addTo(this);
         this._footprintCollection["Footprints"] = this._geoLayer;
         for (let i = 0; i < result.length; i++) {
           for (let j = 0; j < result[i].features.length; j++) {


### PR DESCRIPTION
This is a simple click event to console.log the associated json to each footprint. This will be updated to connect to search results GUI once the GUI is completed.