### PR TITLE
small Fixes and added temporary STAC api link

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -80,7 +80,6 @@
     "@mui/icons-material": "^5.4.1",
     "@mui/lab": "^5.0.0-alpha.68",
     "@mui/material": "^5.4.1",
-    "@mui/material/styles": "^5.4.1",
     "@svgr/webpack": "^6.2.1",
     "autoprefixer": "^10.4.2",
     "date-fns": "^2.28.0",

--- a/app/src/js/ApiJsonCollection.js
+++ b/app/src/js/ApiJsonCollection.js
@@ -20,11 +20,6 @@ function getItemCollection(name, queryString) {
           let link = result.collections[i].links[j];
           if (link.rel == "items") {
             var url = result.collections[i].links[j].href;
-            // this is temporary until stac.astrogeology is working with pagination
-            url = url.replace(
-              "https://stac.astrogeology.usgs.gov/api/collections",
-              "https://jat52qc8c0.execute-api.us-west-2.amazonaws.com/dev/collections"
-            );
             url = url + queryString;
             urlArray.push(url);
           }

--- a/app/src/js/ApiJsonCollection.js
+++ b/app/src/js/ApiJsonCollection.js
@@ -4,7 +4,7 @@ var _numberMatched = 0;
 
 function callAPI() {
   return fetch(
-    "https://stac.astrogeology.usgs.gov/api/collections"
+    "https://6vpdmaqce6.execute-api.us-west-2.amazonaws.com/dev/collections"
   ).then(response => response.json());
 }
 


### PR DESCRIPTION
Temporary API only has Europa footprints but is testable with query parameters.